### PR TITLE
fix the bug: multiple-value uuid.NewV1() in single-value context

### DIFF
--- a/util/function.go
+++ b/util/function.go
@@ -351,7 +351,8 @@ func GenerateNonceStr() string {
 
 /*GenerateUUID GenerateUUID */
 func GenerateUUID() string {
-	s := uuid.NewV1().String()
+	u1, _ := uuid.NewV1()
+	s := u1.String()
 	s = strings.Replace(s, "-", "", -1)
 	run := ([]rune)(s)[:32]
 	return string(run)


### PR DESCRIPTION
fix the bug:
../github.com/godcong/wego/util/function.go:354:17: multiple-value uuid.NewV1() in single-value context